### PR TITLE
I've fixed a bug in the `code_analysis.sh` script to correctly use th…

### DIFF
--- a/memory/development_lessons.txt
+++ b/memory/development_lessons.txt
@@ -1,1 +1,19 @@
-This file will contain development lessons.
+This incident highlighted several important development lessons:
+
+1.  **Environment Configuration:**
+    *   Storing configuration files in a centralized and easily accessible location is crucial. Moving `environment.txt` to the project root from a subdirectory simplified path management and reduced complexity in the scripts.
+    *   When scripts need to be run from different directories, it's important to have a robust way to determine the project root. The `PRISM_QUANTA_ROOT` environment variable, set by a dedicated `setup_environment.sh` script, provides a reliable way to do this.
+
+2.  **Script Portability:**
+    *   Scripts should not rely on the current working directory to locate files. Using absolute paths based on a project root variable makes scripts more portable and less prone to errors.
+    *   Hardcoding relative paths like `../` or `./` can lead to issues when scripts are run from unexpected locations.
+
+3.  **Dependency Management:**
+    *   The `code_analysis.sh` script failed because the `bc` command was not installed. This highlights the importance of identifying and documenting all script dependencies.
+
+4.  **Error Handling and Debugging:**
+    *   The `set -u` option in the scripts was helpful in identifying unbound variables, but it also made the scripts more brittle. It's important to find a balance between strict error checking and script robustness.
+    *   Adding debug statements (e.g., `echo` commands to print variable values) was a useful technique for identifying issues with variable expansion and pathing.
+
+5.  **Testing:**
+    *   Creating a dedicated test script (`test_jules.sh`) was a good way to verify the fixes and ensure that the scripts work as expected. This is a good practice to follow for any future development.

--- a/scripts/code_analysis.sh
+++ b/scripts/code_analysis.sh
@@ -4,10 +4,10 @@ echo "Running code analysis..."
 
 # Language Percentage Analysis
 echo "Language Percentage Analysis:"
-total_files=$(find "$PROJECT_ROOT" -type f -not -path "$PROJECT_ROOT/.git/*" | wc -l)
-cpp_files=$(find "$PROJECT_ROOT" -name "*.cpp" -o -name "*.h" | wc -l)
-sh_files=$(find "$PROJECT_ROOT" -name "*.sh" | wc -l)
-python_files=$(find "$PROJECT_ROOT" -name "*.py" | wc -l)
+total_files=$(find "$PRISM_QUANTA_ROOT" -type f -not -path "$PRISM_QUANTA_ROOT/.git/*" | wc -l)
+cpp_files=$(find "$PRISM_QUANTA_ROOT" -name "*.cpp" -o -name "*.h" | wc -l)
+sh_files=$(find "$PRISM_QUANTA_ROOT" -name "*.sh" | wc -l)
+python_files=$(find "$PRISM_QUANTA_ROOT" -name "*.py" | wc -l)
 
 if [ "$total_files" -ne 0 ]; then
     cpp_percentage=$(echo "scale=2; $cpp_files / $total_files * 100" | bc)
@@ -25,22 +25,22 @@ echo "Python: $python_percentage%"
 
 # Test Case Counting
 echo -e "\nTest Case Counting:"
-test_files=$(find "$PROJECT_ROOT/tests" -type f | wc -l)
+test_files=$(find "$PRISM_QUANTA_ROOT/tests" -type f | wc -l)
 echo "Number of files in /tests directory: $test_files"
-test_cases=$(grep -r -E -i "test|assert" --exclude-dir=".git" "$PROJECT_ROOT" | wc -l)
+test_cases=$(grep -r -E -i "test|assert" --exclude-dir=".git" "$PRISM_QUANTA_ROOT" | wc -l)
 echo "Number of lines containing 'test' or 'assert': $test_cases"
 
 # Key File Size Analysis
 echo -e "\nKey File Size Analysis:"
 echo "Size of .txt and .xml files:"
-find "$PROJECT_ROOT" -name "*.txt" -o -name "*.xml" -exec du -h {} +
+find "$PRISM_QUANTA_ROOT" -name "*.txt" -o -name "*.xml" -exec du -h {} +
 
 # Orphaned File Analysis
 echo -e "\nOrphaned File Analysis (Beta):"
 echo "The following files might be orphaned (not referenced by other files):"
-for file in $(find "$PROJECT_ROOT" -type f -not -path "$PROJECT_ROOT/.git/*" -not -path "$PROJECT_ROOT/scripts/code_analysis.sh"); do
+for file in $(find "$PRISM_QUANTA_ROOT" -type f -not -path "$PRISM_QUANTA_ROOT/.git/*" -not -path "$PRISM_QUANTA_ROOT/scripts/code_analysis.sh"); do
     filename=$(basename "$file")
-    if ! grep -r -q "$filename" --exclude-dir=".git" --exclude="code_analysis.sh" "$PROJECT_ROOT"; then
+    if ! grep -r -q "$filename" --exclude-dir=".git" --exclude="code_analysis.sh" "$PRISM_QUANTA_ROOT"; then
         echo "$file"
     fi
 done


### PR DESCRIPTION
…e `PRISM_QUANTA_ROOT` environment variable when searching for files.