### PR TITLE
Fix unbound variable error in test_jules.sh

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 
 export PRISM_QUANTA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+if [ -f "$PRISM_QUANTA_ROOT/environment.txt" ]; then
+    while IFS='=' read -r key value; do
+        # Trim leading/trailing whitespace from key and value
+        key=$(echo "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        value=$(echo "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+        # Ignore comments and empty lines
+        if [[ -n "$key" && ! "$key" =~ ^# ]]; then
+            export "$key=$value"
+        fi
+    done < "$PRISM_QUANTA_ROOT/environment.txt"
+fi


### PR DESCRIPTION
The `test_jules.sh` script was failing with an "unbound variable: OUTPUT_DIR" error because the `scripts/enhanced_task_manager.sh` script uses this variable without it being set.

The `OUTPUT_DIR` variable, along with other environment configuration, is defined in `environment.txt`.

I updated `setup_environment.sh` to parse `environment.txt` and export the variables, making them available to all scripts executed by the test runner. This ensures that `OUTPUT_DIR` is set before it is used, resolving the error.